### PR TITLE
Changed call to padarray to an array concatenation

### DIFF
--- a/Omicron.m
+++ b/Omicron.m
@@ -68,7 +68,7 @@ classdef Omicron
             end
 
             if length(ydata)<length(xvalues)
-                ydata = padarray(ydata,len(xvalues)-length(ydata),nan,'post');
+                ydata = [ydata, NaN(1, length(xvalues)-length(ydata))];
             end
             
         end


### PR DESCRIPTION
The function padarray is only available when you have the image processing toolbox installed. I changed it to an array concatenation so that this code can be used with the basic MATLAB environment.